### PR TITLE
JwtAuthenticationFilter 구현

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,12 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <scope>annotationProcessor</scope>
+        </dependency>
     </dependencies>
     <dependencyManagement>
         <dependencies>

--- a/src/main/java/site/caboomlog/gatewayservice/config/WebClientConfig.java
+++ b/src/main/java/site/caboomlog/gatewayservice/config/WebClientConfig.java
@@ -1,0 +1,17 @@
+package site.caboomlog.gatewayservice.config;
+
+import org.springframework.cloud.client.loadbalancer.LoadBalanced;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+
+    @Bean
+    @LoadBalanced
+    public WebClient.Builder webClientBuilder() {
+        return WebClient.builder();
+    }
+}
+

--- a/src/main/java/site/caboomlog/gatewayservice/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/site/caboomlog/gatewayservice/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,62 @@
+package site.caboomlog.gatewayservice.jwt;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.filter.GlobalFilter;
+import org.springframework.http.MediaType;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.http.HttpStatus.UNAUTHORIZED;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter implements GlobalFilter {
+
+    private final WebClient.Builder webClientBuilder;
+
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+        ServerHttpRequest request = exchange.getRequest();
+        String path = request.getURI().getPath();
+
+        if (path.contains("/login") || path.contains("/signup") || path.contains("/topic")) {
+            return chain.filter(exchange);
+        }
+
+        String authHeader = request.getHeaders().getFirst(AUTHORIZATION);
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            exchange.getResponse().setStatusCode(UNAUTHORIZED);
+            return exchange.getResponse().setComplete();
+        }
+
+        String token = authHeader.replace("Bearer ", "");
+
+        return webClientBuilder.build()
+                .post()
+                .uri("http://token-service/token/validate")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(new TokenValidationRequest(token))
+                .retrieve()
+                .bodyToMono(TokenValidationResponse.class)
+                .flatMap(response -> {
+                    if (!response.isValid()) {
+                        exchange.getResponse().setStatusCode(UNAUTHORIZED);
+                        return exchange.getResponse().setComplete();
+                    }
+
+                    ServerHttpRequest modifiedRequest = request.mutate()
+                            .header("caboomlog-mb-no", String.valueOf(response.getMbNo()))
+                            .build();
+                    return chain.filter(exchange.mutate().request(modifiedRequest).build());
+                })
+                .onErrorResume(e -> {
+                    exchange.getResponse().setStatusCode(UNAUTHORIZED);
+                    return exchange.getResponse().setComplete();
+                });
+    }
+}

--- a/src/main/java/site/caboomlog/gatewayservice/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/site/caboomlog/gatewayservice/jwt/JwtAuthenticationFilter.java
@@ -24,7 +24,8 @@ public class JwtAuthenticationFilter implements GlobalFilter {
         ServerHttpRequest request = exchange.getRequest();
         String path = request.getURI().getPath();
 
-        if (path.contains("/login") || path.contains("/signup") || path.contains("/topic")) {
+        if (path.contains("/login") || path.contains("/signup") ||
+                path.contains("/topic") || path.contains("refresh")) {
             return chain.filter(exchange);
         }
 

--- a/src/main/java/site/caboomlog/gatewayservice/jwt/TokenValidationRequest.java
+++ b/src/main/java/site/caboomlog/gatewayservice/jwt/TokenValidationRequest.java
@@ -1,0 +1,10 @@
+package site.caboomlog.gatewayservice.jwt;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class TokenValidationRequest {
+    private String token;
+}

--- a/src/main/java/site/caboomlog/gatewayservice/jwt/TokenValidationResponse.java
+++ b/src/main/java/site/caboomlog/gatewayservice/jwt/TokenValidationResponse.java
@@ -1,0 +1,11 @@
+package site.caboomlog.gatewayservice.jwt;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class TokenValidationResponse {
+    private boolean valid;
+    private Long mbNo;
+}


### PR DESCRIPTION
1. front-service로부터 요청을 받으면 authorization header 의 액세스 토큰을 "Bearer " 제거
2. "Bearer " 제거된 액세스 토큰을 token-service로 보내 토큰 유효성 검증 후 mbNo 응답받음
3-1. 검증되면, mbNo를 caboomlog-mb-no 헤더에 담아 라우팅
3-2. 검증되지 않으면, 401 응답